### PR TITLE
Fix typo in Readme Postgree -> Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Written in ASP.NET Core 3.1 and Angular 8.
 - Argon2 Password Hashing
 - MySql Ready
 - Sql Ready
-- Postgree Ready
+- Postgres Ready
 - SQLite Ready
 - Entity Framework Core
 - .NET Core Native DI


### PR DESCRIPTION
Just a typo I noticed while reading the README file.