### PR TITLE
Corrected null check on username

### DIFF
--- a/src/Frontend/Jp.UI.SSO/Controllers/Account/AccountController.cs
+++ b/src/Frontend/Jp.UI.SSO/Controllers/Account/AccountController.cs
@@ -664,7 +664,7 @@ namespace Jp.UI.SSO.Controllers.Account
 
             var user = new SocialViewModel()
             {
-                Username = username == null ? username : email,
+                Username = username ?? email,
                 Name = name,
                 Email = email,
                 Picture = picture,


### PR DESCRIPTION
I have had the application fail when trying to use an External login because the username cannot be null. 

I think this check is wrong and is intended to take the email parameter when the username is not null.
